### PR TITLE
Override `ActionView::Template::Handlers::ERB:Erubi` initialize method to set `@output_buffer`

### DIFF
--- a/core/config/initializers/action_view.rb
+++ b/core/config/initializers/action_view.rb
@@ -1,0 +1,22 @@
+module ActionView
+  class Template
+    module Handlers
+      class ERB
+        class Erubi < ::Erubi::Engine
+          def initialize(input, properties = {})
+            @newline_pending = 0
+
+            # Dup properties so that we don't modify argument
+            properties = Hash[properties]
+            properties[:preamble]   = "@output_buffer = output_buffer || ActionView::OutputBuffer.new;"
+            properties[:postamble]  = "@output_buffer.to_s"
+            properties[:bufvar]     = "@output_buffer"
+            properties[:escapefunc] = ""
+
+            super
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
There're 2 failing examples but I'm not sure if this is the right solution and I have no idea how this changes can influence them.