### PR TITLE
SD-421 Add plus to cursor, keep overlay withing photo

### DIFF
--- a/frontend/app/assets/images/picture-zoom.svg
+++ b/frontend/app/assets/images/picture-zoom.svg
@@ -1,15 +1,31 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="22.573" height="22.505" viewBox="0 0 22.573 22.505">
+<svg xmlns="http://www.w3.org/2000/svg" width="21.167" height="21.12" viewBox="0 0 21.167 21.12">
   <defs>
     <style>
-      .cls-1 {
+      .cls-1, .cls-2 {
         fill: #232323;
+      }
+
+      .cls-1 {
         stroke: #232323;
+        stroke-width: 0.4px;
       }
     </style>
   </defs>
-  <g data-name="Group 519" transform="translate(-679.5 -214.339)">
-    <g transform="translate(680 214.839)">
-      <path data-name="Path 6" class="cls-1" d="M21.364,20.408l-5.226-5.226a9.177,9.177,0,1,0-.906.906l5.226,5.226a.648.648,0,0,0,.453.191.628.628,0,0,0,.453-.191A.645.645,0,0,0,21.364,20.408ZM1.333,9.169a7.882,7.882,0,1,1,7.882,7.887A7.891,7.891,0,0,1,1.333,9.169Z" transform="translate(-0.05 0)"/>
+  <g data-name="Group 599" transform="translate(-687.083 -196.854)">
+    <g data-name="Group 597" transform="translate(6.703 -11.947)">
+      <g data-name="Group 595" transform="translate(680.58 209.002)">
+        <g data-name="Group 593" transform="translate(0 0)">
+          <g data-name="Group 519" transform="translate(0 0)">
+            <g id="magnifying-glass">
+              <path data-name="Path 6" class="cls-1" d="M20.586,19.663l-5.035-5.035a8.842,8.842,0,1,0-.873.873l5.035,5.035a.624.624,0,0,0,.436.184.605.605,0,0,0,.436-.184A.621.621,0,0,0,20.586,19.663ZM1.286,8.835a7.594,7.594,0,1,1,7.594,7.6A7.6,7.6,0,0,1,1.286,8.835Z" transform="translate(-0.05 0)"/>
+            </g>
+          </g>
+        </g>
+      </g>
+    </g>
+    <g data-name="Group 598" transform="translate(-1 -1)">
+      <rect data-name="Rectangle 165" class="cls-2" width="2" height="8" transform="translate(696 203)"/>
+      <rect data-name="Rectangle 166" class="cls-2" width="2" height="8" transform="translate(693 208) rotate(-90)"/>
     </g>
   </g>
 </svg>

--- a/frontend/app/assets/stylesheets/spree/frontend/views/spree/shared/carousel/single.scss
+++ b/frontend/app/assets/stylesheets/spree/frontend/views/spree/shared/carousel/single.scss
@@ -105,7 +105,9 @@
     right: 0;
     top: 0;
     z-index: 1;
+    justify-content: center;
     &-modal-opener {
+      flex-basis: 430px;
       cursor: image-url('picture-zoom.svg'), auto
     }
   }


### PR DESCRIPTION
Fixed issues:
Magnifying glass does not have '+' inside of it
The overlay should cover 100% os screen size without border.

