### PR TITLE
[SD-571] Moving home and taxons controllers from spree/designs

### DIFF
--- a/frontend/app/controllers/spree/home_controller.rb
+++ b/frontend/app/controllers/spree/home_controller.rb
@@ -4,10 +4,28 @@ module Spree
     respond_to :html
 
     def index
-      @searcher = build_searcher(params.merge(include_images: true))
-      @products = @searcher.retrieve_products
-      @products = @products.includes(:possible_promotions) if @products.respond_to?(:includes)
+      @bestsellers_products = load_taxon_products('Bestsellers')
+      @trending_products = load_taxon_products('Trending')
       @taxonomies = Spree::Taxonomy.includes(root: :children)
+
+      @combined_products = [@bestsellers_products, @trending_products].flatten.uniq
+    end
+
+    private
+
+    def load_taxon_products(taxon_name)
+      Spree::Product.joins(:taxons)
+                    .where(spree_taxons: { name: taxon_name })
+                    .eager_load(
+                      :variants_including_master,
+                      master: [
+                        :default_price,
+                        { images: { attachment_attachment: :blob } }
+                      ]
+                    )
+                    .available
+                    .limit(12)
+                    .to_a
     end
   end
 end

--- a/frontend/app/controllers/spree/taxons_controller.rb
+++ b/frontend/app/controllers/spree/taxons_controller.rb
@@ -5,12 +5,12 @@ module Spree
     respond_to :html
 
     def show
-      @taxon = Taxon.friendly.find(params[:id])
-      return unless @taxon
+      @taxon = Spree::Taxon.friendly.find(params[:id])
 
       @searcher = build_searcher(params.merge(taxon: @taxon.id, include_images: true))
       @products = @searcher.retrieve_products
       @taxonomies = Spree::Taxonomy.includes(root: :children)
+      @option_types = Spree::OptionType.includes(:option_values)
     end
 
     private


### PR DESCRIPTION
Connected with https://github.com/spark-solutions/spree-designs/pull/255