### PR TITLE
SR-104 Top Products by Line Item Totals - Incorrect name in Admin dropdown

### DIFF
--- a/backend/app/views/spree/admin/reports/customers/show.html.erb
+++ b/backend/app/views/spree/admin/reports/customers/show.html.erb
@@ -1,4 +1,4 @@
-<%= render partial: 'spree/admin/reports/header', locals: { title: Spree.t(:total_sales) } %>
+<%= render partial: 'spree/admin/reports/header', locals: { title: Spree.t(:customers) } %>
 <%= render partial: 'spree/admin/reports/filters' %>
 
 <canvas

--- a/backend/app/views/spree/admin/reports/top_products_by_line_item_totals/show.html.erb
+++ b/backend/app/views/spree/admin/reports/top_products_by_line_item_totals/show.html.erb
@@ -1,4 +1,4 @@
-<%= render partial: 'spree/admin/reports/header', locals: { title: Spree.t(:average_order_values) } %>
+<%= render partial: 'spree/admin/reports/header', locals: { title: Spree.t(:top_products_by_line_item_totals) } %>
 <%= render partial: 'spree/admin/reports/filters' %>
 
 <canvas

--- a/backend/app/views/spree/admin/shared/sub_menu/_report.html.erb
+++ b/backend/app/views/spree/admin/shared/sub_menu/_report.html.erb
@@ -3,6 +3,6 @@
   <%= tab :reports_total_orders, match_path: '/reports/total_orders' %>
   <%= tab :reports_average_order_values, match_path: '/reports/average_order_values' %>
   <%= tab :reports_top_products_by_unit_sold, match_path: '/reports/top_products_by_unit_sold' %>
-  <%= tab :reports_top_products_by_line_item_totals, match_path: '/reports/top_products_by_line_item_totals' %>
-  <%= tab :reports_customers, match_path: '/reports/customers' %>
+  <%= tab :reports_top_products_by_line_item_totals, label: Spree.t(:top_products_by_line_item_totals), match_path: '/reports/top_products_by_line_item_totals' %>
+  <%= tab :reports_customers, label: Spree.t(:customers), match_path: '/reports/customers' %>
 </ul>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -728,6 +728,7 @@ en:
     current: Current
     current_promotion_usage: ! 'Current Usage: %{count}'
     customer: Customer
+    customers: Customers
     customer_details: Customer Details
     customer_details_updated: Customer Details Updated
     customer_return: Customer Return
@@ -1645,6 +1646,7 @@ en:
     total_customers: Total customers
     total_orders: Total Orders
     top_products_by_unit_sold: Top Products By Unit Sold
+    top_products_by_line_item_totals: Top Products By Line Item Totals
     average_order_value: Average Order Value
     orders_count: Orders Count
     total_per_item: Total per item


### PR DESCRIPTION
Apart from main issue this PR also fixing bellow issues: 
1. Fix name Top Products By Line Item Totals on report page
2. Fix incorrect name on Customers report page
3. Fix incorrect name Customers in menu